### PR TITLE
fix: add macOS (Darwin) support for install/deploy/uninstall/update s…

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@
 
 ### 🚀 快速开始
 > [!IMPORTANT]
-> 本项目须安装在安装了 OpenClaw 的 **Linux 主机**上，且必须是 **原生安装**（非 Docker）。
+> 本项目须安装在安装了 OpenClaw 的主机上，且必须是 **原生安装**（非 Docker）。支持 **Linux** 和 **macOS** 系统。
 
 #### 📥 一键安装
 
@@ -57,6 +57,28 @@ curl -fsSL https://raw.githubusercontent.com/liandu2024/OpenClaw-Chat-Gateway/ma
 ```bash
 curl -fsSL https://raw.githubusercontent.com/liandu2024/OpenClaw-Chat-Gateway/main/install.sh | bash -s 8080
 ```
+
+<details>
+<summary>🍎 macOS 用户注意</summary>
+
+macOS 使用 `launchd` 管理服务（而非 Linux 的 systemd），安装脚本已自动适配。安装完成后可通过以下命令管理服务：
+
+```bash
+# 查看服务状态
+launchctl list | grep clawui
+
+# 查看日志
+cat /tmp/clawui-3115.log
+cat /tmp/clawui-3115-err.log
+
+# 停止服务
+launchctl unload ~/Library/LaunchAgents/com.clawui-3115.plist
+
+# 启动服务
+launchctl load ~/Library/LaunchAgents/com.clawui-3115.plist
+```
+
+</details>
 
 #### 🆙 无损升级
 ```bash
@@ -81,9 +103,16 @@ curl -fsSL https://raw.githubusercontent.com/liandu2024/OpenClaw-Chat-Gateway/ma
 ---
 
 ### 💡 提示：预览增强
-如果您需要预览 Word, PPT, Excel 等文档，请运行以下指令安装 LibreOffice：
+如果您需要预览 Word, PPT, Excel 等文档，请安装 LibreOffice：
+
+**Linux:**
 ```bash
 sudo apt update && sudo apt install libreoffice -y
+```
+
+**macOS:**
+```bash
+brew install --cask libreoffice
 ```
 
 ### 💬 社群与支持
@@ -126,7 +155,7 @@ sudo apt update && sudo apt install libreoffice -y
 
 ### 🚀 Quick Start
 > [!IMPORTANT]
-> This project must be installed on a **Linux host** where OpenClaw is already installed, and it must be a **native installation** (not Docker).
+> This project must be installed on a host where OpenClaw is already installed, and it must be a **native installation** (not Docker). Both **Linux** and **macOS** are supported.
 
 #### 📥 One-Click Installation
 
@@ -139,6 +168,28 @@ curl -fsSL https://raw.githubusercontent.com/liandu2024/OpenClaw-Chat-Gateway/ma
 ```bash
 curl -fsSL https://raw.githubusercontent.com/liandu2024/OpenClaw-Chat-Gateway/main/install.sh | bash -s 8080
 ```
+
+<details>
+<summary>🍎 macOS Notes</summary>
+
+macOS uses `launchd` for service management (instead of Linux's systemd). The install script automatically adapts. After installation, manage the service with:
+
+```bash
+# Check service status
+launchctl list | grep clawui
+
+# View logs
+cat /tmp/clawui-3115.log
+cat /tmp/clawui-3115-err.log
+
+# Stop service
+launchctl unload ~/Library/LaunchAgents/com.clawui-3115.plist
+
+# Start service
+launchctl load ~/Library/LaunchAgents/com.clawui-3115.plist
+```
+
+</details>
 
 #### 🆙 Non-Destructive Upgrade
 ```bash
@@ -163,9 +214,16 @@ Meticulously crafted mobile details, providing not just responsiveness, but imme
 ---
 
 ### 💡 Tip: Enhanced Preview
-If you need to preview documents like Word, PPT, or Excel, please run the following command to install LibreOffice:
+If you need to preview documents like Word, PPT, or Excel, install LibreOffice:
+
+**Linux:**
 ```bash
 sudo apt update && sudo apt install libreoffice -y
+```
+
+**macOS:**
+```bash
+brew install --cask libreoffice
 ```
 
 ### 💬 Community & Support

--- a/clawui.plist.template
+++ b/clawui.plist.template
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>CLAWUI_LABEL</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>NODE_PATH</string>
+        <string>dist/index.js</string>
+    </array>
+    <key>WorkingDirectory</key>
+    <string>CLAWUI_WORKDIR/backend</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PORT</key>
+        <string>CLAWUI_PORT</string>
+        <key>NODE_ENV</key>
+        <string>production</string>
+        <key>CLAWUI_DATA_DIR</key>
+        <string>.clawui_release</string>
+    </dict>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+    <key>StandardOutPath</key>
+    <string>/tmp/clawui-CLAWUI_PORT.log</string>
+    <key>StandardErrorPath</key>
+    <string>/tmp/clawui-CLAWUI_PORT-err.log</string>
+</dict>
+</plist>

--- a/deploy-release.sh
+++ b/deploy-release.sh
@@ -3,11 +3,40 @@ set -e
 
 # Configuration
 PROJECT_ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-SERVICE_DIR="$HOME/.config/systemd/user"
 SKIP_SERVICE_RESTART=${CLAWUI_SKIP_SERVICE_RESTART:-0}
 BROWSER_WARMUP_MARKER="$HOME/${CLAWUI_DATA_DIR:-.clawui}/browser-warmup.pending"
 
+# Detect OS
+OS_TYPE="$(uname -s)"
+
+# Set service directories based on OS
+if [ "$OS_TYPE" = "Darwin" ]; then
+    SERVICE_DIR="$HOME/Library/LaunchAgents"
+    SERVICE_EXT="plist"
+else
+    SERVICE_DIR="$HOME/.config/systemd/user"
+    SERVICE_EXT="service"
+fi
+
 export PATH="$HOME/.npm-global/bin:$HOME/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:$PATH"
+
+# Cross-platform sed in-place: macOS BSD sed requires backup suffix, GNU sed does not
+sed_inplace() {
+    if [ "$OS_TYPE" = "Darwin" ]; then
+        sed -i '' "$@"
+    else
+        sed -i "$@"
+    fi
+}
+
+# Cross-platform get local IP
+get_local_ip() {
+    if [ "$OS_TYPE" = "Darwin" ]; then
+        ipconfig getifaddr en0 2>/dev/null || echo ""
+    else
+        hostname -I 2>/dev/null | awk '{print $1}' || echo ""
+    fi
+}
 
 emit_phase() {
     echo "::clawui-update-phase::$1"
@@ -32,6 +61,7 @@ echo "Deploying OpenClaw Chat Gateway (Consolidated)..."
 echo "Project Path:  $PROJECT_ROOT"
 echo "Service Port:  $CLAWUI_PORT"
 echo "Service Name:  $SERVICE_NAME"
+echo "OS Type:       $OS_TYPE"
 
 echo "Installing dependencies..."
 cd "$PROJECT_ROOT"
@@ -49,35 +79,69 @@ echo "Patching OpenClaw configuration for local backend connections..."
 node backend/patch-config.js || echo "Warning: Failed to patch OpenClaw config automatically."
 
 emit_phase "setup-service"
-echo "Setting up systemd service..."
-mkdir -p "$SERVICE_DIR"
+if [ "$OS_TYPE" = "Darwin" ]; then
+    # ── macOS: launchd setup ──
+    echo "Setting up launchd service (macOS)..."
 
-# Clean up old services if they exist (legacy single service name)
-if [ "$CLAWUI_PORT" == "3115" ] && [ -f "$SERVICE_DIR/clawui.service" ]; then
-    echo "Transitioning from legacy clawui.service to $SERVICE_NAME.service..."
-    systemctl --user stop clawui.service 2>/dev/null || true
-    systemctl --user disable clawui.service 2>/dev/null || true
-    rm -f "$SERVICE_DIR/clawui.service"
-fi
+    PLIST_FILE="$SERVICE_DIR/com.$SERVICE_NAME.plist"
 
-# Copy and update the consolidated service file
-cp "$PROJECT_ROOT/clawui.service" "$SERVICE_DIR/$SERVICE_NAME.service"
+    # Stop and unload existing service if present
+    if [ -f "$PLIST_FILE" ]; then
+        echo "Unloading existing service..."
+        launchctl unload "$PLIST_FILE" 2>/dev/null || true
+    fi
 
-# Update WorkingDirectory, Port, and Description in the service file
-sed -i "s|WorkingDirectory=.*|WorkingDirectory=$PROJECT_ROOT/backend|" "$SERVICE_DIR/$SERVICE_NAME.service"
-sed -i "s/Environment=PORT=.*/Environment=PORT=$CLAWUI_PORT/" "$SERVICE_DIR/$SERVICE_NAME.service"
-sed -i "s/Description=.*/Description=ClawUI Service (Port $CLAWUI_PORT)/" "$SERVICE_DIR/$SERVICE_NAME.service"
-if grep -q '^Environment=PATH=' "$SERVICE_DIR/$SERVICE_NAME.service"; then
-    sed -i "s|^Environment=PATH=.*|Environment=PATH=$HOME/.npm-global/bin:$HOME/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin|" "$SERVICE_DIR/$SERVICE_NAME.service"
+    # Find Node.js path
+    NODE_BIN="$(command -v node)"
+    if [ -z "$NODE_BIN" ]; then
+        echo "Error: Could not find node in PATH."
+        exit 1
+    fi
+
+    # Generate plist from template
+    mkdir -p "$SERVICE_DIR"
+    cp "$PROJECT_ROOT/clawui.plist.template" "$PLIST_FILE"
+
+    sed_inplace "s|CLAWUI_LABEL|com.$SERVICE_NAME|g" "$PLIST_FILE"
+    sed_inplace "s|CLAWUI_PORT|$CLAWUI_PORT|g" "$PLIST_FILE"
+    sed_inplace "s|CLAWUI_WORKDIR|$PROJECT_ROOT|g" "$PLIST_FILE"
+    sed_inplace "s|NODE_PATH|$NODE_BIN|g" "$PLIST_FILE"
+
+    echo "Loading launchd service..."
+    launchctl load "$PLIST_FILE"
+
 else
-    sed -i "/Environment=NODE_ENV=.*/a Environment=PATH=$HOME/.npm-global/bin:$HOME/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" "$SERVICE_DIR/$SERVICE_NAME.service"
+    # ── Linux: systemd setup ──
+    echo "Setting up systemd service..."
+    mkdir -p "$SERVICE_DIR"
+
+    # Clean up old services if they exist (legacy single service name)
+    if [ "$CLAWUI_PORT" == "3115" ] && [ -f "$SERVICE_DIR/clawui.service" ]; then
+        echo "Transitioning from legacy clawui.service to $SERVICE_NAME.service..."
+        systemctl --user stop clawui.service 2>/dev/null || true
+        systemctl --user disable clawui.service 2>/dev/null || true
+        rm -f "$SERVICE_DIR/clawui.service"
+    fi
+
+    # Copy and update the consolidated service file
+    cp "$PROJECT_ROOT/clawui.service" "$SERVICE_DIR/$SERVICE_NAME.service"
+
+    # Update WorkingDirectory, Port, and Description in the service file
+    sed_inplace "s|WorkingDirectory=.*|WorkingDirectory=$PROJECT_ROOT/backend|" "$SERVICE_DIR/$SERVICE_NAME.service"
+    sed_inplace "s/Environment=PORT=.*/Environment=PORT=$CLAWUI_PORT/" "$SERVICE_DIR/$SERVICE_NAME.service"
+    sed_inplace "s/Description=.*/Description=ClawUI Service (Port $CLAWUI_PORT)/" "$SERVICE_DIR/$SERVICE_NAME.service"
+    if grep -q '^Environment=PATH=' "$SERVICE_DIR/$SERVICE_NAME.service"; then
+        sed_inplace "s|^Environment=PATH=.*|Environment=PATH=$HOME/.npm-global/bin:$HOME/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin|" "$SERVICE_DIR/$SERVICE_NAME.service"
+    else
+        sed_inplace "/Environment=NODE_ENV=.*/a Environment=PATH=$HOME/.npm-global/bin:$HOME/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" "$SERVICE_DIR/$SERVICE_NAME.service"
+    fi
+
+    echo "Reloading systemd daemon..."
+    systemctl --user daemon-reload
+
+    echo "Enabling service $SERVICE_NAME..."
+    systemctl --user enable "$SERVICE_NAME.service"
 fi
-
-echo "Reloading systemd daemon..."
-systemctl --user daemon-reload
-
-echo "Enabling service $SERVICE_NAME..."
-systemctl --user enable "$SERVICE_NAME.service"
 
 if [ "$SKIP_SERVICE_RESTART" = "1" ]; then
     echo "Skipping service restart because CLAWUI_SKIP_SERVICE_RESTART=1"
@@ -94,17 +158,25 @@ else
     echo "Restarting service $SERVICE_NAME..."
     mkdir -p "$(dirname "$BROWSER_WARMUP_MARKER")"
     touch "$BROWSER_WARMUP_MARKER"
-    systemctl --user restart "$SERVICE_NAME.service"
+
+    if [ "$OS_TYPE" = "Darwin" ]; then
+        launchctl unload "$SERVICE_DIR/com.$SERVICE_NAME.plist" 2>/dev/null || true
+        launchctl load "$SERVICE_DIR/com.$SERVICE_NAME.plist"
+    else
+        systemctl --user restart "$SERVICE_NAME.service"
+    fi
 fi
 
-# Ensure services stay running after logout
-echo "Enabling lingering for user $(whoami)..."
-if command -v loginctl >/dev/null 2>&1; then
-    sudo -n loginctl enable-linger $(whoami) || echo "Warning: Could not enable lingering. Manual action may be required: sudo loginctl enable-linger $(whoami)"
+# Ensure services stay running after logout (Linux only)
+if [ "$OS_TYPE" != "Darwin" ]; then
+    echo "Enabling lingering for user $(whoami)..."
+    if command -v loginctl >/dev/null 2>&1; then
+        sudo -n loginctl enable-linger $(whoami) || echo "Warning: Could not enable lingering. Manual action may be required: sudo loginctl enable-linger $(whoami)"
+    fi
 fi
 
 # Get local IP address
-LOCAL_IP=$(hostname -I | awk '{print $1}')
+LOCAL_IP=$(get_local_ip)
 [ -z "$LOCAL_IP" ] && LOCAL_IP="localhost"
 
 echo "------------------------------------------------"
@@ -112,4 +184,10 @@ echo "Deployment complete!"
 echo "Local Access:   http://localhost:$CLAWUI_PORT"
 echo "Network Access: http://$LOCAL_IP:$CLAWUI_PORT"
 echo "------------------------------------------------"
-echo "Check status with: systemctl --user status $SERVICE_NAME"
+if [ "$OS_TYPE" = "Darwin" ]; then
+    echo "Check status with: launchctl list | grep $SERVICE_NAME"
+    echo "View logs with:    cat /tmp/clawui-$CLAWUI_PORT.log"
+    echo "Stop service:      launchctl unload ~/Library/LaunchAgents/com.$SERVICE_NAME.plist"
+else
+    echo "Check status with: systemctl --user status $SERVICE_NAME"
+fi

--- a/install.sh
+++ b/install.sh
@@ -5,11 +5,23 @@ set -e
 REPO_URL="https://github.com/liandu2024/OpenClaw-Chat-Gateway.git"
 INSTALL_DIR="$HOME/OpenClaw-Chat-Gateway"
 
+# Detect OS
+OS_TYPE="$(uname -s)"
+
 # Terminal Colors
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 BLUE='\033[0;34m'
 NC='\033[0m' # No Color
+
+# Cross-platform get local IP
+get_local_ip() {
+    if [ "$OS_TYPE" = "Darwin" ]; then
+        ipconfig getifaddr en0 2>/dev/null || echo ""
+    else
+        hostname -I 2>/dev/null | awk '{print $1}' || echo ""
+    fi
+}
 
 restore_deploy_lockfiles() {
     git restore -- package-lock.json backend/package-lock.json frontend/package-lock.json 2>/dev/null || true
@@ -55,7 +67,7 @@ chmod +x deploy-release.sh
 ./deploy-release.sh "$1" # Pass single port argument if provided
 
 # Get local IP address
-LOCAL_IP=$(hostname -I | awk '{print $1}')
+LOCAL_IP=$(get_local_ip)
 [ -z "$LOCAL_IP" ] && LOCAL_IP="localhost"
 
 echo -e "\n${GREEN}================================================${NC}"
@@ -67,5 +79,9 @@ echo -e "网络访问:   http://$LOCAL_IP:${1:-3115}"
 echo -e "安装目录:   $INSTALL_DIR"
 echo -e "------------------------------------------------"
 echo -e "${BLUE}提示: 安装 LibreOffice 可以获得更好的文档预览体验。${NC}"
-echo -e "安装指令: ${GREEN}sudo apt update && sudo apt install libreoffice -y${NC}"
+if [ "$OS_TYPE" = "Darwin" ]; then
+    echo -e "安装指令: ${GREEN}brew install --cask libreoffice${NC}"
+else
+    echo -e "安装指令: ${GREEN}sudo apt update && sudo apt install libreoffice -y${NC}"
+fi
 echo -e "------------------------------------------------"

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -3,8 +3,9 @@ set -e
 
 # Configuration
 INSTALL_DIR="$HOME/OpenClaw-Chat-Gateway"
-SERVICE_NAME="clawui.service"
-SERVICE_PATH="$HOME/.config/systemd/user/$SERVICE_NAME"
+
+# Detect OS
+OS_TYPE="$(uname -s)"
 
 # Terminal Colors
 RED='\033[0;31m'
@@ -13,18 +14,29 @@ BLUE='\033[0;34m'
 NC='\033[0m' # No Color
 
 # 探测安装目录和数据目录
-SERVICE_DIR="$HOME/.config/systemd/user"
 DB_PATH="$HOME/.clawui/clawui.sqlite"
 WORKSPACE_BASE="$HOME/.openclaw"
-SERVICES=$(ls $SERVICE_DIR/clawui-*.service 2>/dev/null || true)
-if [ -f "$SERVICE_DIR/clawui.service" ]; then
-    SERVICES="$SERVICES $SERVICE_DIR/clawui.service"
+
+if [ "$OS_TYPE" = "Darwin" ]; then
+    SERVICE_DIR="$HOME/Library/LaunchAgents"
+    SERVICES=$(ls $SERVICE_DIR/com.clawui-*.plist 2>/dev/null || true)
+else
+    SERVICE_DIR="$HOME/.config/systemd/user"
+    SERVICES=$(ls $SERVICE_DIR/clawui-*.service 2>/dev/null || true)
+    if [ -f "$SERVICE_DIR/clawui.service" ]; then
+        SERVICES="$SERVICES $SERVICE_DIR/clawui.service"
+    fi
 fi
 
 DETECTED_DIRS=""
 for S_PATH in $SERVICES; do
-    W_DIR=$(grep "^WorkingDirectory=" "$S_PATH" | cut -d'=' -f2 | sed 's/ /\\ /g')
-    P_DIR=$(dirname "$W_DIR")
+    if [ "$OS_TYPE" = "Darwin" ]; then
+        W_DIR=$(grep -A1 '<key>WorkingDirectory</key>' "$S_PATH" | tail -1 | sed 's/.*<string>\(.*\)<\/string>.*/\1/' | sed 's|/backend$||')
+    else
+        W_DIR=$(grep "^WorkingDirectory=" "$S_PATH" | cut -d'=' -f2 | sed 's/ /\\ /g')
+        W_DIR=$(dirname "$W_DIR")
+    fi
+    P_DIR="$W_DIR"
     if [ -d "$P_DIR" ]; then
         DETECTED_DIRS="$DETECTED_DIRS $P_DIR"
     fi
@@ -55,11 +67,9 @@ fi
 OPENCLAW_CONFIG="$WORKSPACE_BASE/openclaw.json"
 if [ -f "$OPENCLAW_CONFIG" ]; then
     if command -v jq &>/dev/null; then
-        # 使用 jq 提取所有 workspace 路径
         JSON_WS=$(jq -r '.agents.list[].workspace' "$OPENCLAW_CONFIG" 2>/dev/null || true)
         TARGET_WORKSPACES="$TARGET_WORKSPACES $JSON_WS"
     else
-        # 兜底：使用 grep/sed 提取 workspace 路径内容
         JSON_WS=$(grep '"workspace":' "$OPENCLAW_CONFIG" | sed 's/.*"workspace": "\(.*\)".*/\1/' || true)
         TARGET_WORKSPACES="$TARGET_WORKSPACES $JSON_WS"
     fi
@@ -67,7 +77,6 @@ fi
 
 # 来源 3: 启发式扫描 (查找包含 SOUL.md 的 workspace-* 目录)
 if [ -d "$WORKSPACE_BASE" ]; then
-    # 扫描目录下所有的 workspace- 开头的目录
     H_WS=$(find "$WORKSPACE_BASE" -maxdepth 2 -type f -name "SOUL.md" | xargs -I {} dirname {} | grep "/workspace-" || true)
     TARGET_WORKSPACES="$TARGET_WORKSPACES $H_WS"
 fi
@@ -106,14 +115,22 @@ fi
 
 # 停止并移除服务
 echo -e "\n${BLUE}步骤 1: 正在停止并移除系统服务...${NC}"
-for S_PATH in $SERVICES; do
-    S_FILE=$(basename "$S_PATH")
-    echo "正在停止服务: $S_FILE"
-    systemctl --user stop "$S_FILE" 2>/dev/null || true
-    systemctl --user disable "$S_FILE" 2>/dev/null || true
-    rm "$S_PATH"
-done
-systemctl --user daemon-reload
+if [ "$OS_TYPE" = "Darwin" ]; then
+    for S_PATH in $SERVICES; do
+        echo "正在停止服务: $(basename "$S_PATH")"
+        launchctl unload "$S_PATH" 2>/dev/null || true
+        rm "$S_PATH"
+    done
+else
+    for S_PATH in $SERVICES; do
+        S_FILE=$(basename "$S_PATH")
+        echo "正在停止服务: $S_FILE"
+        systemctl --user stop "$S_FILE" 2>/dev/null || true
+        systemctl --user disable "$S_FILE" 2>/dev/null || true
+        rm "$S_PATH"
+    done
+    systemctl --user daemon-reload
+fi
 
 # 移除数据和日志
 echo -e "\n${BLUE}步骤 2: 正在清理本项目相关的数据和设置...${NC}"
@@ -128,6 +145,10 @@ done
 rm -rf "$HOME/.clawui"
 rm -rf "$HOME/.clawui_release"
 [ -d "$HOME/.clawui_dev" ] && rm -rf "$HOME/.clawui_dev"
+
+# Remove macOS log files
+rm -f /tmp/clawui-*.log /tmp/clawui-*-err.log 2>/dev/null || true
+
 echo "已清理本项目相关的配置和数据库数据。"
 
 # 移除项目文件

--- a/update.sh
+++ b/update.sh
@@ -5,6 +5,9 @@ set -e
 # If not in a project dir, default to ~/OpenClaw-Chat-Gateway
 INSTALL_DIR="$HOME/OpenClaw-Chat-Gateway"
 
+# Detect OS
+OS_TYPE="$(uname -s)"
+
 emit_phase() {
     echo "::clawui-update-phase::$1"
 }
@@ -23,7 +26,11 @@ else
     exit 1
 fi
 
-SERVICE_DIR="$HOME/.config/systemd/user"
+if [ "$OS_TYPE" = "Darwin" ]; then
+    SERVICE_DIR="$HOME/Library/LaunchAgents"
+else
+    SERVICE_DIR="$HOME/.config/systemd/user"
+fi
 
 echo "================================================"
 echo "   OpenClaw Chat Gateway - 更新脚本"
@@ -32,18 +39,30 @@ echo "================================================"
 # 1. 从服务文件中探测现有端口
 emit_phase "detect-service"
 EXISTING_PORT=""
-SERVICES=$(ls $SERVICE_DIR/clawui-*.service 2>/dev/null | sort -V || true)
 
-if [ -n "$SERVICES" ]; then
-    # 使用找到的第一个服务端口作为默认值
-    FIRST_SERVICE=$(echo "$SERVICES" | head -n 1)
-    EXISTING_PORT=$(basename "$FIRST_SERVICE" | sed 's/clawui-\([0-9]*\)\.service/\1/')
-    echo "检测到正在运行的端口: $EXISTING_PORT"
+if [ "$OS_TYPE" = "Darwin" ]; then
+    # macOS: look for launchd plist files
+    SERVICES=$(ls $SERVICE_DIR/com.clawui-*.plist 2>/dev/null | sort -V || true)
+
+    if [ -n "$SERVICES" ]; then
+        FIRST_SERVICE=$(echo "$SERVICES" | head -n 1)
+        EXISTING_PORT=$(basename "$FIRST_SERVICE" | sed 's/com\.clawui-\([0-9]*\)\.plist/\1/')
+        echo "检测到正在运行的端口: $EXISTING_PORT"
+    fi
 else
-    # 检查旧版服务文件
-    if [ -f "$SERVICE_DIR/clawui.service" ]; then
-        EXISTING_PORT="3115"
-        echo "检测到旧版安装 (端口 3115)"
+    # Linux: look for systemd service files
+    SERVICES=$(ls $SERVICE_DIR/clawui-*.service 2>/dev/null | sort -V || true)
+
+    if [ -n "$SERVICES" ]; then
+        FIRST_SERVICE=$(echo "$SERVICES" | head -n 1)
+        EXISTING_PORT=$(basename "$FIRST_SERVICE" | sed 's/clawui-\([0-9]*\)\.service/\1/')
+        echo "检测到正在运行的端口: $EXISTING_PORT"
+    else
+        # 检查旧版服务文件
+        if [ -f "$SERVICE_DIR/clawui.service" ]; then
+            EXISTING_PORT="3115"
+            echo "检测到旧版安装 (端口 3115)"
+        fi
     fi
 fi
 


### PR DESCRIPTION
…cripts

The install script and service management were Linux-only, causing two breakages on macOS:

1. BSD sed requires a backup suffix with -i (GNU sed does not), producing "undefined label" errors
2. systemctl/systemd doesn't exist on macOS — launchd is the native service manager

Changes:
- deploy-release.sh: detect OS, add launchd plist setup branch for macOS alongside systemd branch for Linux; add sed_inplace() wrapper and get_local_ip() helper
- install.sh: use macOS-compatible IP detection (ipconfig getifaddr) and show Homebrew LibreOffice install hint on macOS
- uninstall.sh: add launchctl unload/remove path for macOS plist services
- update.sh: detect existing services from LaunchAgents on macOS
- Add clawui.plist.template for macOS launchd service generation